### PR TITLE
Release fix delay test

### DIFF
--- a/src/DabMod.cpp
+++ b/src/DabMod.cpp
@@ -71,6 +71,8 @@
 
 #define ZMQ_INPUT_MAX_FRAME_QUEUE 500
 
+// Default makes it match with old hard-coded settings.
+#define ZMQ_INPUT_QUEUE_RESTART_DEPTH ZMQ_INPUT_MAX_FRAME_QUEUE - 3
 
 typedef std::complex<float> complexf;
 
@@ -121,6 +123,7 @@ int launch_modulator(int argc, char* argv[])
     std::string inputName = "";
     std::string inputTransport = "file";
     unsigned inputMaxFramesQueued = ZMQ_INPUT_MAX_FRAME_QUEUE;
+    unsigned inputQueueRestartDepth = ZMQ_INPUT_QUEUE_RESTART_DEPTH;
 
     std::string outputName;
     int useZeroMQOutput = 0;
@@ -370,6 +373,8 @@ int launch_modulator(int argc, char* argv[])
         inputTransport = pt.get("input.transport", "file");
         inputMaxFramesQueued = pt.get("input.max_frames_queued",
                 ZMQ_INPUT_MAX_FRAME_QUEUE);
+        inputQueueRestartDepth = pt.get("input.restart_depth",
+                ZMQ_INPUT_QUEUE_RESTART_DEPTH);
 
         inputName = pt.get("input.source", "/dev/stdin");
 
@@ -701,7 +706,7 @@ int launch_modulator(int argc, char* argv[])
         ret = -1;
         throw std::runtime_error("Unable to open input");
 #else
-        inputZeroMQReader->Open(inputName, inputMaxFramesQueued);
+        inputZeroMQReader->Open(inputName, inputMaxFramesQueued, inputQueueRestartDepth);
         m.inputReader = inputZeroMQReader.get();
 #endif
     }
@@ -812,7 +817,7 @@ int launch_modulator(int argc, char* argv[])
                     run_again = true;
                     // Create a new input reader
                     inputZeroMQReader = make_shared<InputZeroMQReader>();
-                    inputZeroMQReader->Open(inputName, inputMaxFramesQueued);
+                    inputZeroMQReader->Open(inputName, inputMaxFramesQueued, inputQueueRestartDepth);
                     m.inputReader = inputZeroMQReader.get();
 #endif
                 }

--- a/src/InputReader.h
+++ b/src/InputReader.h
@@ -150,6 +150,7 @@ struct InputZeroMQThreadData
     ThreadsafeQueue<std::shared_ptr<std::vector<uint8_t> > > *in_messages;
     std::string uri;
     size_t max_queued_frames;
+	size_t restart_queue_depth;
 };
 
 class InputZeroMQWorker
@@ -194,7 +195,7 @@ class InputZeroMQReader : public InputReader
             worker_.Stop();
         }
 
-        int Open(const std::string& uri, size_t max_queued_frames);
+        int Open(const std::string& uri, size_t max_queued_frames, size_t restart_depth = 0);
 
         int GetNextFrame(void* buffer);
 

--- a/src/InputReader.h
+++ b/src/InputReader.h
@@ -158,7 +158,7 @@ class InputZeroMQWorker
         InputZeroMQWorker() :
             running(false),
             zmqcontext(1),
-            m_to_drop(0) { }
+            m_to_drop(40) { }
 
         void Start(struct InputZeroMQThreadData* workerdata);
         void Stop();

--- a/src/InputReader.h
+++ b/src/InputReader.h
@@ -158,7 +158,7 @@ class InputZeroMQWorker
         InputZeroMQWorker() :
             running(false),
             zmqcontext(1),
-            m_to_drop(40) { }
+            m_to_drop(0) { }
 
         void Start(struct InputZeroMQThreadData* workerdata);
         void Stop();

--- a/src/InputZeroMQReader.cpp
+++ b/src/InputZeroMQReader.cpp
@@ -228,8 +228,7 @@ void InputZeroMQWorker::RecvProcess(struct InputZeroMQThreadData* workerdata)
                  * phase.
                  */
                 // m_to_drop = 3;
-                // make sure max_queued_frames is at least 16 ETI-frames.
-                m_to_drop = workerdata->max_queued_frames - (16 / NUM_FRAMES_PER_ZMQ_MESSAGE);
+                m_to_drop = workerdata->max_queued_frames / 2;
 
             }
 

--- a/src/InputZeroMQReader.cpp
+++ b/src/InputZeroMQReader.cpp
@@ -134,7 +134,7 @@ void InputZeroMQWorker::RecvProcess(struct InputZeroMQThreadData* workerdata)
     // zmq sockets are not thread safe. That's why
     // we create it here, and not at object creation.
 
-    const int hwm = 25;
+    const int hwm = 5;
     const int linger = 0;
     try {
         subscriber.setsockopt(ZMQ_RCVHWM, &hwm, sizeof(hwm));
@@ -143,7 +143,7 @@ void InputZeroMQWorker::RecvProcess(struct InputZeroMQThreadData* workerdata)
         subscriber.connect(workerdata->uri.c_str());
         subscriber.setsockopt(ZMQ_SUBSCRIBE, NULL, 0); // subscribe to all messages
 
-        size_t throwFrames = 25;
+        size_t throwFrames = 12;
         while (running)
         {
             zmq::message_t incoming;

--- a/src/InputZeroMQReader.cpp
+++ b/src/InputZeroMQReader.cpp
@@ -230,12 +230,12 @@ void InputZeroMQWorker::RecvProcess(struct InputZeroMQThreadData* workerdata)
                 if(workerdata->restart_queue_depth != 0)
                 {
                     etiLog.level(warn) << "ZMQ,resetting ZeroMQ buffer to: " << workerdata->restart_queue_depth;
-                    m_to_drop = (workerdata->max_queued_frames - workerdata->restart_queue_depth) / 2;
+                    m_to_drop = (workerdata->max_queued_frames - workerdata->restart_queue_depth) / 4;
                 }
                 else
                 {
                     etiLog.level(warn) << "ZMQ,resetting ZeroMQ buffer to: " << workerdata->max_queued_frames / 2;
-                    m_to_drop = workerdata->max_queued_frames / 2;
+                    m_to_drop = workerdata->max_queued_frames / 4;
                 }
             }
 

--- a/src/InputZeroMQReader.cpp
+++ b/src/InputZeroMQReader.cpp
@@ -220,7 +220,6 @@ void InputZeroMQWorker::RecvProcess(struct InputZeroMQThreadData* workerdata)
                     //throw std::runtime_error("ZMQ input full");
                 }
 
-				workerdata->in_messages->clear();
                 queue_size = workerdata->in_messages->size();
 
                 /* Drop three more incoming ETI frames before
@@ -228,8 +227,8 @@ void InputZeroMQWorker::RecvProcess(struct InputZeroMQThreadData* workerdata)
                  * that we keep transmission frame vs. ETI frame
                  * phase.
                  */
-                // m_to_drop = 3;
-                //m_to_drop = workerdata->max_queued_frames / 2;
+                //m_to_drop = 3;
+                m_to_drop = workerdata->max_queued_frames / 2;
 
             }
 

--- a/src/InputZeroMQReader.cpp
+++ b/src/InputZeroMQReader.cpp
@@ -143,7 +143,7 @@ void InputZeroMQWorker::RecvProcess(struct InputZeroMQThreadData* workerdata)
         subscriber.connect(workerdata->uri.c_str());
         subscriber.setsockopt(ZMQ_SUBSCRIBE, NULL, 0); // subscribe to all messages
 
-        size_t throwFrames = 12;
+        size_t throwFrames = 0;
         while (running)
         {
             zmq::message_t incoming;

--- a/src/InputZeroMQReader.cpp
+++ b/src/InputZeroMQReader.cpp
@@ -144,6 +144,9 @@ void InputZeroMQWorker::RecvProcess(struct InputZeroMQThreadData* workerdata)
         subscriber.connect(workerdata->uri.c_str());
         subscriber.setsockopt(ZMQ_SUBSCRIBE, NULL, 0); // subscribe to all messages
 
+        etiLog.level(trace) << "ZMQ,workerdata->max_queued_frames: " << workerdata->max_queued_frames;
+        etiLog.level(trace) << "ZMQ,workerdata->restart_queue_depth: " << workerdata->restart_queue_depth;
+
         size_t throwFrames = 0;
         while (running)
         {
@@ -226,10 +229,12 @@ void InputZeroMQWorker::RecvProcess(struct InputZeroMQThreadData* workerdata)
                 //m_to_drop = 3;
                 if(workerdata->restart_queue_depth != 0)
                 {
+                    etiLog.level(warn) << "resetting ZeroMQ buffer to: " << workerdata->restart_queue_depth;
                     m_to_drop = workerdata->max_queued_frames - workerdata->restart_queue_depth;
                 }
                 else
                 {
+                    etiLog.level(warn) << "resetting ZeroMQ buffer to: " << workerdata->max_queued_frames / 2;
                     m_to_drop = workerdata->max_queued_frames / 2;
                 }
             }

--- a/src/InputZeroMQReader.cpp
+++ b/src/InputZeroMQReader.cpp
@@ -212,7 +212,7 @@ void InputZeroMQWorker::RecvProcess(struct InputZeroMQThreadData* workerdata)
                 workerdata->in_messages->notify();
 
                 if (!buffer_full) {
-                    etiLog.level(warn) << "ZeroMQ buffer overfull !";
+                    etiLog.level(warn) << "ZMQ,ZeroMQ buffer overfull !";
 
                     buffer_full = true;
 
@@ -229,18 +229,18 @@ void InputZeroMQWorker::RecvProcess(struct InputZeroMQThreadData* workerdata)
                 //m_to_drop = 3;
                 if(workerdata->restart_queue_depth != 0)
                 {
-                    etiLog.level(warn) << "resetting ZeroMQ buffer to: " << workerdata->restart_queue_depth;
-                    m_to_drop = workerdata->max_queued_frames - workerdata->restart_queue_depth;
+                    etiLog.level(warn) << "ZMQ,resetting ZeroMQ buffer to: " << workerdata->restart_queue_depth;
+                    m_to_drop = (workerdata->max_queued_frames - workerdata->restart_queue_depth) / 2;
                 }
                 else
                 {
-                    etiLog.level(warn) << "resetting ZeroMQ buffer to: " << workerdata->max_queued_frames / 2;
+                    etiLog.level(warn) << "ZMQ,resetting ZeroMQ buffer to: " << workerdata->max_queued_frames / 2;
                     m_to_drop = workerdata->max_queued_frames / 2;
                 }
             }
 
             if (queue_size < 5) {
-                etiLog.level(warn) << "ZeroMQ buffer low: " << queue_size << " elements !";
+                etiLog.level(warn) << "ZMQ,ZeroMQ buffer low: " << queue_size << " elements !";
             }
         }
     }

--- a/src/InputZeroMQReader.cpp
+++ b/src/InputZeroMQReader.cpp
@@ -228,8 +228,8 @@ void InputZeroMQWorker::RecvProcess(struct InputZeroMQThreadData* workerdata)
                  * phase.
                  */
                 // m_to_drop = 3;
-                // make sure max_queued_frames is at least 20 frames.
-                m_to_drop = workerdata->max_queued_frames - 20;
+                // make sure max_queued_frames is at least 16 ETI-frames.
+                m_to_drop = workerdata->max_queued_frames - (16 / NUM_FRAMES_PER_ZMQ_MESSAGE);
 
             }
 

--- a/src/InputZeroMQReader.cpp
+++ b/src/InputZeroMQReader.cpp
@@ -143,7 +143,7 @@ void InputZeroMQWorker::RecvProcess(struct InputZeroMQThreadData* workerdata)
         subscriber.connect(workerdata->uri.c_str());
         subscriber.setsockopt(ZMQ_SUBSCRIBE, NULL, 0); // subscribe to all messages
 
-        size_t throwFrames = 0;
+        size_t throwFrames = 20;
         while (running)
         {
             zmq::message_t incoming;

--- a/src/InputZeroMQReader.cpp
+++ b/src/InputZeroMQReader.cpp
@@ -134,7 +134,7 @@ void InputZeroMQWorker::RecvProcess(struct InputZeroMQThreadData* workerdata)
     // zmq sockets are not thread safe. That's why
     // we create it here, and not at object creation.
 
-    const int hwm = 5;
+    const int hwm = 10;
     const int linger = 0;
     try {
         subscriber.setsockopt(ZMQ_RCVHWM, &hwm, sizeof(hwm));

--- a/src/InputZeroMQReader.cpp
+++ b/src/InputZeroMQReader.cpp
@@ -228,7 +228,8 @@ void InputZeroMQWorker::RecvProcess(struct InputZeroMQThreadData* workerdata)
                  * phase.
                  */
                 // m_to_drop = 3;
-                m_to_drop = workerdata->max_queued_frames - 8;
+                // make sure max_queued_frames is at least 20 frames.
+                m_to_drop = workerdata->max_queued_frames - 20;
 
             }
 

--- a/src/InputZeroMQReader.cpp
+++ b/src/InputZeroMQReader.cpp
@@ -134,7 +134,7 @@ void InputZeroMQWorker::RecvProcess(struct InputZeroMQThreadData* workerdata)
     // zmq sockets are not thread safe. That's why
     // we create it here, and not at object creation.
 
-    const int hwm = 50;
+    const int hwm = 30;
     const int linger = 0;
     try {
         subscriber.setsockopt(ZMQ_RCVHWM, &hwm, sizeof(hwm));
@@ -143,7 +143,7 @@ void InputZeroMQWorker::RecvProcess(struct InputZeroMQThreadData* workerdata)
         subscriber.connect(workerdata->uri.c_str());
         subscriber.setsockopt(ZMQ_SUBSCRIBE, NULL, 0); // subscribe to all messages
 
-        size_t throwFrames = 20;
+        size_t throwFrames = 0;
         while (running)
         {
             zmq::message_t incoming;

--- a/src/InputZeroMQReader.cpp
+++ b/src/InputZeroMQReader.cpp
@@ -143,18 +143,18 @@ void InputZeroMQWorker::RecvProcess(struct InputZeroMQThreadData* workerdata)
         subscriber.connect(workerdata->uri.c_str());
         subscriber.setsockopt(ZMQ_SUBSCRIBE, NULL, 0); // subscribe to all messages
 
-        // size_t throwFrames = 50;
+        size_t throwFrames = 25;
         while (running)
         {
             zmq::message_t incoming;
             subscriber.recv(&incoming);
 
-            // if(throwFrames > 0)
-            // {   // Drop first throwFrames number of frames received. 
-                // // It is most likely old frames from frame source HWM-buffer.
-                // --throwFrames;
-                // continue;
-            // }
+            if(throwFrames > 0)
+            {   // Drop first throwFrames number of frames received. 
+                // It is most likely old frames from frame source HWM-buffer.
+                --throwFrames;
+                continue;
+            }
 
             if (m_to_drop) {
                 queue_size = workerdata->in_messages->size();

--- a/src/InputZeroMQReader.cpp
+++ b/src/InputZeroMQReader.cpp
@@ -134,7 +134,7 @@ void InputZeroMQWorker::RecvProcess(struct InputZeroMQThreadData* workerdata)
     // zmq sockets are not thread safe. That's why
     // we create it here, and not at object creation.
 
-    const int hwm = 10;
+    const int hwm = 50;
     const int linger = 0;
     try {
         subscriber.setsockopt(ZMQ_RCVHWM, &hwm, sizeof(hwm));
@@ -220,6 +220,7 @@ void InputZeroMQWorker::RecvProcess(struct InputZeroMQThreadData* workerdata)
                     //throw std::runtime_error("ZMQ input full");
                 }
 
+				workerdata->in_messages->clear();
                 queue_size = workerdata->in_messages->size();
 
                 /* Drop three more incoming ETI frames before
@@ -228,7 +229,7 @@ void InputZeroMQWorker::RecvProcess(struct InputZeroMQThreadData* workerdata)
                  * phase.
                  */
                 // m_to_drop = 3;
-                m_to_drop = workerdata->max_queued_frames / 2;
+                //m_to_drop = workerdata->max_queued_frames / 2;
 
             }
 

--- a/src/InputZeroMQReader.cpp
+++ b/src/InputZeroMQReader.cpp
@@ -228,7 +228,7 @@ void InputZeroMQWorker::RecvProcess(struct InputZeroMQThreadData* workerdata)
                  * phase.
                  */
                 //m_to_drop = 3;
-                //m_to_drop = workerdata->max_queued_frames / 2;
+                m_to_drop = workerdata->max_queued_frames - 12;
 
             }
 

--- a/src/InputZeroMQReader.cpp
+++ b/src/InputZeroMQReader.cpp
@@ -228,7 +228,7 @@ void InputZeroMQWorker::RecvProcess(struct InputZeroMQThreadData* workerdata)
                  * phase.
                  */
                 //m_to_drop = 3;
-                m_to_drop = workerdata->max_queued_frames / 2;
+                //m_to_drop = workerdata->max_queued_frames / 2;
 
             }
 

--- a/src/OutputUHD.cpp
+++ b/src/OutputUHD.cpp
@@ -767,8 +767,17 @@ void UHDWorker::handle_frame(const struct UHDWorkerFrameData *frame)
                     "%d underruns and %d late packets since last status.\n",
                     usrp_time,
                     num_underflows, num_late_packets);
-			//boost::this_thread::sleep(boost::posix_time::milliseconds(1000));
+
+			if(++num_consecutive_underflow_msgs > 10)
+			{
+				num_consecutive_underflow_msgs = 0;
+				boost::this_thread::sleep(boost::posix_time::milliseconds(1000));
+			}
         }
+		else
+		{
+			num_consecutive_underflow_msgs = 0;
+		}
         num_underflows = 0;
         num_late_packets = 0;
 

--- a/src/OutputUHD.cpp
+++ b/src/OutputUHD.cpp
@@ -619,6 +619,7 @@ void UHDWorker::process()
 
     num_underflows   = 0;
     num_late_packets = 0;
+	num_consecutive_underflow_msgs = 0;
 
     while (uwd->running) {
         md.has_time_spec  = false;
@@ -768,7 +769,7 @@ void UHDWorker::handle_frame(const struct UHDWorkerFrameData *frame)
                     usrp_time,
                     num_underflows, num_late_packets);
 
-			if(++num_consecutive_underflow_msgs > 10)
+			if(++num_consecutive_underflow_msgs > 25)
 			{
 				num_consecutive_underflow_msgs = 0;
 				//boost::this_thread::sleep(boost::posix_time::milliseconds(1000));

--- a/src/OutputUHD.cpp
+++ b/src/OutputUHD.cpp
@@ -784,17 +784,17 @@ void UHDWorker::handle_frame(const struct UHDWorkerFrameData *frame)
 
             //boost::this_thread::sleep(boost::posix_time::milliseconds(100));
             process_extra_frame = true;
-            if(++num_consecutive_underflow_msgs > 20)
+            if(++num_consecutive_underflow_msgs > 10)
             {
                 num_consecutive_underflow_msgs = 0;
                 //boost::this_thread::sleep(boost::posix_time::milliseconds(1000));
                 throw std::runtime_error("Too many consecutive underruns. Indicates unspecified internal problem, exiting...");
             }
         }
-		else
-		{
-			num_consecutive_underflow_msgs = 0;
-		}
+        else
+        {
+            num_consecutive_underflow_msgs = 0;
+        }
         num_underflows = 0;
         num_late_packets = 0;
 

--- a/src/OutputUHD.cpp
+++ b/src/OutputUHD.cpp
@@ -771,7 +771,8 @@ void UHDWorker::handle_frame(const struct UHDWorkerFrameData *frame)
 			if(++num_consecutive_underflow_msgs > 10)
 			{
 				num_consecutive_underflow_msgs = 0;
-				boost::this_thread::sleep(boost::posix_time::milliseconds(1000));
+				//boost::this_thread::sleep(boost::posix_time::milliseconds(1000));
+				throw std::runtime_error("Too many consecutive underruns. Indicates unspecified internal problem, exiting...");
 			}
         }
 		else

--- a/src/OutputUHD.cpp
+++ b/src/OutputUHD.cpp
@@ -635,11 +635,14 @@ void UHDWorker::process()
 
         if(process_extra_frame)
         {
-            etiLog.log(trace, "UHD,produce extra frame");
-            etiLog.log(trace, "UHD,wait");
-            uwd->frames.wait_and_pop(frame);
-            etiLog.log(trace, "UHD,pop");
-            handle_frame(&frame);
+            for (int loop = 0; loop < 5; ++loop)
+            {
+                etiLog.log(trace, "UHD,produce extra frame");
+                etiLog.log(trace, "UHD,wait");
+                uwd->frames.wait_and_pop(frame);
+                etiLog.log(trace, "UHD,pop");
+                handle_frame(&frame);
+            }
         }
     }
 }

--- a/src/OutputUHD.cpp
+++ b/src/OutputUHD.cpp
@@ -767,7 +767,7 @@ void UHDWorker::handle_frame(const struct UHDWorkerFrameData *frame)
                     "%d underruns and %d late packets since last status.\n",
                     usrp_time,
                     num_underflows, num_late_packets);
-			boost::this_thread::sleep(boost::posix_time::milliseconds(1000));
+			//boost::this_thread::sleep(boost::posix_time::milliseconds(1000));
         }
         num_underflows = 0;
         num_late_packets = 0;

--- a/src/OutputUHD.cpp
+++ b/src/OutputUHD.cpp
@@ -124,8 +124,7 @@ OutputUHD::OutputUHD(
     first_run(true),
     gps_fix_verified(false),
     worker(&uwd),
-    myDelayBuf(0),
-	process_extra_frame(false)
+    myDelayBuf(0)
 {
     myConf.muting = true;     // is remote-controllable, and reset by the GPS fix check
     myConf.staticDelayUs = 0; // is remote-controllable
@@ -620,7 +619,8 @@ void UHDWorker::process()
 
     num_underflows   = 0;
     num_late_packets = 0;
-	num_consecutive_underflow_msgs = 0;
+    num_consecutive_underflow_msgs = 0;
+    process_extra_frame = false;
 
     while (uwd->running) {
         md.has_time_spec  = false;

--- a/src/OutputUHD.h
+++ b/src/OutputUHD.h
@@ -154,6 +154,7 @@ class UHDWorker {
         // Asynchronous message statistics
         int num_underflows;
         int num_late_packets;
+        int num_consecutive_underflow_msgs;
 
         uhd::tx_metadata_t md;
         bool     last_tx_time_initialised;

--- a/src/OutputUHD.h
+++ b/src/OutputUHD.h
@@ -52,6 +52,7 @@ DESCRIPTION:
 #include <chrono>
 #include <memory>
 #include <string>
+#include <atomic>
 
 #include "Log.h"
 #include "ModOutput.h"
@@ -275,6 +276,8 @@ class OutputUHD: public ModOutput, public RemoteControllable {
         boost::packaged_task<bool> gps_fix_pt;
         boost::unique_future<bool> gps_fix_future;
         boost::thread gps_fix_task;
+
+        std::atomic<bool> process_extra_frame;
 
         // Wait time in seconds to get fix
         static const int initial_gps_fix_wait = 180;

--- a/src/OutputUHD.h
+++ b/src/OutputUHD.h
@@ -156,6 +156,7 @@ class UHDWorker {
         int num_underflows;
         int num_late_packets;
         int num_consecutive_underflow_msgs;
+        std::atomic<bool> process_extra_frame;
 
         uhd::tx_metadata_t md;
         bool     last_tx_time_initialised;
@@ -276,8 +277,6 @@ class OutputUHD: public ModOutput, public RemoteControllable {
         boost::packaged_task<bool> gps_fix_pt;
         boost::unique_future<bool> gps_fix_future;
         boost::thread gps_fix_task;
-
-        std::atomic<bool> process_extra_frame;
 
         // Wait time in seconds to get fix
         static const int initial_gps_fix_wait = 180;


### PR DESCRIPTION
Fixes #DEV-89
https://paneda.myjetbrains.com/youtrack/issue/DEV-89

With the massive default-buffers in ODR-DabMod, a large delay can be built up over time when mux produces data a bit faster than the modulator transmits it. 

The ODR-DabMod now handles overflows in a proper manner.
Makes use of the 'max_frames_queued'-variable with some modifications and adds a 'restart_depth'-variable to odr.ini. 

Buffer underruns are modified to not trigger at first appearance. It now needs 10 consecutive underrun-notifications before it exits and lets the appkeeper restart it. Sometimes a couple of underruns happens during start-up and should no longer lead to an immediate exit.

It might be possible to avoid a restart at underrun if we add code to feed the modulator old frames while we build up the buffer again... but that's for another pull-request. 

